### PR TITLE
카카오 로그인 콜백 처리 개선 및 사용자 정보 조회 API 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,9 +8,9 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Loginpage />} />
-        <Route path="/login/kakao" element={<LoginKakaoCallback />} />
+        <Route path="/login/callback" element={<LoginKakaoCallback />} />
         <Route path="/home" element={<Home />} />
-      </Routes>
+      </Routes>ß
     </BrowserRouter>
   );
 }

--- a/src/pages/LoginKakkoCallback.jsx
+++ b/src/pages/LoginKakkoCallback.jsx
@@ -1,32 +1,25 @@
 // src/pages/LoginKakkoCallback.jsx
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 const LoginKakkoCallback = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   useEffect(() => {
-    const getToken = async () => {
-      try {
-        const response = await fetch("http://localhost:8080/oauth2/success", {
-          method: "GET",
-          credentials: "include",
-        });
+    const accessToken = searchParams.get("accessToken");
 
-        const data = await response.json();
-        const { accessToken } = data;
+    if (accessToken) {
+      localStorage.setItem("accessToken", accessToken);
 
-        localStorage.setItem("accessToken", accessToken);
+      // 2. URL에서 쿼리스트링 제거
+      window.history.replaceState({}, "", "/login/callback");
 
-        // ✅ 로그인 성공 시 /home으로 이동
-        navigate("/home");
-      } catch (error) {
-        console.error("로그인 실패", error);
-      }
-    };
-
-    getToken();
-  }, [navigate]);
+      navigate("/home"); // ✅ 로그인 성공 시 이동
+    } else {
+      console.error("AccessToken이 존재하지 않습니다.");
+    }
+  }, [navigate, searchParams]);
 
   return <div>로그인 처리 중입니다...</div>;
 };

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -9,7 +9,7 @@ const Home = () => {
   useEffect(() => {
     const fetchUser = async () => {
       try {
-        const res = await authFetch("http://localhost:8080/api/user/me");
+        const res = await authFetch("http://localhost:8080/user");
         const data = await res.json();
         setUser(data);
       } catch (err) {


### PR DESCRIPTION
✨ 작업 내용
- 카카오 로그인 콜백 라우트 경로를 /login/kakao에서 /login/callback으로 수정했습니다.
- 콜백 페이지에서 백엔드 API 요청 방식에서 URL 쿼리 파라미터(accessToken)를 직접 파싱하여 처리하는 방식으로 변경했습니다.
- 토큰이 성공적으로 전달되면 로컬 스토리지에 저장하고 /home 페이지로 이동합니다.
- /home 페이지에서 사용자 정보를 가져오는 API 경로를 /api/user/me에서 /user로 변경했습니다.