### PR TITLE
복구

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import DetailMyRecord from "./pages/DetailMyRecord";
 import Courses from "./pages/Courses";
 import CourseDetail from "./pages/CourseDetail";
 import MyPage from "./pages/MyPage";
+import RecoverPage from "./pages/RecoverPage";
 
 function App() {
   return (
@@ -16,10 +17,11 @@ function App() {
       <Route path="/home" element={<Home />} />
       <Route path="/login/callback" element={<LoginKakkoCallback />} />
       <Route path="/my-records" element={<MyRecords />} />
-      <Route path="/record/:id" element={<DetailMyRecord />} />
+      <Route path="/my-records/:id" element={<DetailMyRecord />} />
       <Route path="/courses" element={<Courses />} />
       <Route path="/course/:id" element={<CourseDetail />} />
       <Route path="/mypage" element={<MyPage />} />
+      <Route path="/recover" element={<RecoverPage />} />
     </Routes>
   );
 }

--- a/src/pages/DetailMyRecord.jsx
+++ b/src/pages/DetailMyRecord.jsx
@@ -1,6 +1,7 @@
 // src/pages/detailMyRecord.jsx
 import { useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import styles from "./myRecords.module.css";
 import { useAuthFetch } from "../utils/useAuthFetch"; // 인증된 fetch 훅
 
@@ -10,16 +11,12 @@ const DetailMyRecord = () => {
   const polylineRef = useRef(null);
   const [record, setRecord] = useState(null);
   const authFetch = useAuthFetch();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchRecord = async () => {
       try {
-        const res = await authFetch(`http://localhost:8080/running-record
-          /${id}`, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-          },
-        });
+        const res = await authFetch(`http://localhost:8080/running-record/${id}`);
         if (!res.ok) throw new Error("기록 불러오기 실패");
         const data = await res.json();
         setRecord(data);
@@ -40,8 +37,8 @@ const DetailMyRecord = () => {
       level: 5,
     };
     mapRef.current = new window.kakao.maps.Map(container, options);
-
-    const pathData = JSON.parse(record.pathGeoJson);
+    console.log("🔥 record.pathGeoJson:", record?.pathGeoJson);
+    const pathData = record.pathGeoJson;
     const linePath = pathData.coordinates.map(([lng, lat]) =>
       new window.kakao.maps.LatLng(lat, lng)
     );
@@ -60,6 +57,30 @@ const DetailMyRecord = () => {
 
   if (!record) return <div className={styles.container}>로딩 중...</div>;
 
+  const handleDelete = async () => {
+
+  if (!window.confirm("삭제 후 복구 페이지로 이동합니다. 계속할까요?")) return; 
+    
+  try {
+    // 복구용 데이터를 로컬스토리지에 저장
+    localStorage.setItem("unsavedRun", JSON.stringify({
+      distance: record.totalDistance,
+      time: record.totalTime,
+      pace: record.pace
+    }));
+
+    // 실제 서버에서 기록 삭제 (소프트 삭제로 PATCH 사용 중)
+    await authFetch(`http://localhost:8080/running-record/${record.id}/delete`, {
+      method: "PATCH",
+    });
+
+    // 복구 페이지로 이동
+    navigate("/recover");
+  } catch (err) {
+    console.error("❌ 삭제 실패:", err);
+  }
+};
+
   return (
     <div className={styles.container}>
       <h2>📍 상세 러닝 기록</h2>
@@ -67,10 +88,14 @@ const DetailMyRecord = () => {
       <div className={styles.recordDetail}>
         <p><strong>시작 시간:</strong> {new Date(record.startedTime).toLocaleString()}</p>
         <p><strong>종료 시간:</strong> {new Date(record.endedTime).toLocaleString()}</p>
-        <p><strong>총 거리:</strong> {record.distance} km</p>
-        <p><strong>소요 시간:</strong> {Math.floor(record.time / 60)}분 {record.time % 60}초</p>
-        <p><strong>평균 페이스:</strong> {record.pace}</p>
+        <p><strong>총 거리:</strong> {record.totalDistance} km</p>
+        <p><strong>소요 시간:</strong> {Math.floor(record.totalTime / 60)}분 {record.totalTime % 60}초</p>
+        <p><strong>페이스:</strong> {record.pace} 분/km</p>
       </div>
+      {/* ✅ 삭제 버튼 */}
+    <button onClick={handleDelete} className={styles.deleteButton}>
+      🗑️ 기록 삭제
+    </button>
     </div>
   );
 };

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import MyRecords from "./MyRecords";
 import MyRecommendedCourses from "./MyRecommendedCourses";
 import MyFavorites from "./MyFavorites";
+import RecoverPage from "./RecoverPage";
 import styles from "./myPage.module.css";
 
 const MyPage = () => {
@@ -30,6 +31,12 @@ const MyPage = () => {
           className={tab === "favorites" ? styles.active : ""}
         >
           ⭐ 즐겨찾기한 코스
+        </button>
+        <button
+          onClick={() => setTab("recover")}
+          className={tab === "recover" ? styles.active : ""}
+        >
+          📦 복구
         </button>
       </div>
 

--- a/src/pages/MyRecords.jsx
+++ b/src/pages/MyRecords.jsx
@@ -61,45 +61,6 @@ const MyRecords = () => {
   const handleClick = (id) => {
     navigate(`/my-records/${id}`);
   };
-
-  const toggleFavorite = async (record) => {
-    const isFavorite = record.favorite === true;
-
-    try {
-      if (isFavorite) {
-        await authFetch(`http://localhost:8080/favorite/${record.id}`, {
-          method: "DELETE",
-        });
-        alert("⭐ 즐겨찾기에서 삭제됨");
-        setRecords((prev) =>
-          prev.map((r) => (r.id === record.id ? { ...r, favorite: false } : r))
-        );
-      } else {
-        await authFetch(`http://localhost:8080/favorite`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ recordId: record.id }),
-        });
-        alert("⭐ 즐겨찾기에 추가됨");
-        setRecords((prev) =>
-          prev.map((r) => (r.id === record.id ? { ...r, favorite: true } : r))
-        );
-      }
-    } catch (err) {
-      console.error("즐겨찾기 토글 오류:", err);
-    }
-  };
-
-  const handleDelete = async (recordId) => {
-    try {
-      await authFetch(`http://localhost:8080/running-record/${recordId}/delete`, {
-        method: "PATCH",
-      });
-      setRecords((prev) => prev.filter((r) => r.id !== recordId));
-    } catch (err) {
-      console.error("❌ 삭제 실패:", err);
-    }
-  };
   
   return (
     <div className={styles.container}>
@@ -124,17 +85,6 @@ const MyRecords = () => {
               <p><strong>거리:</strong> {record.totalDistance} km</p>
               <p><strong>시간:</strong> {Math.floor(record.totalTime / 60)}분 {record.totalTime % 60}초</p>
               <p><strong>페이스:</strong> {record.pace}</p>
-              <div className={styles.actions}>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDelete(record.id);
-                  }}
-                  className={styles.deleteButton}
-                >
-                  🗑️ 삭제
-                </button>
-              </div>
             </li>
           ))}
         </ul>
@@ -142,44 +92,5 @@ const MyRecords = () => {
     </div>
   );
 };
-
-
-              {/* <div className={styles.actions}>
-                {record.isDeleted ? (
-                  <button onClick={() => handleRestore(record.id)}>♻️ 복구</button>
-                ) : (
-                  <>
-                    <span
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        toggleFavorite(record);
-                      }}
-                      style={{
-                        cursor: "pointer",
-                        fontSize: "20px",
-                        color: record.favorite ? "gold" : "#ccc",
-                      }}
-                    >
-                      ⭐
-                    </span>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDelete(record.id);
-                      }}
-                      className={styles.deleteButton}
-                    >
-                      🗑️ 삭제
-                    </button>
-                  </>
-                )}
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  ); */}
-// };
 
 export default MyRecords;

--- a/src/pages/RecoverPage.jsx
+++ b/src/pages/RecoverPage.jsx
@@ -44,8 +44,28 @@ const RecoverPage = () => {
 
   const handleCancel = () => {
     localStorage.removeItem("unsavedRun");
-    navigate("/home");
+    navigate("/recover");
   };
+
+  const handlePermanentDelete = async (recordId) => {
+  if (window.confirm("영구적으로 삭제됩니다. 계속하시겠습니까?")) {
+    try {
+      await authFetch(`http://localhost:8080/running-record/${recordId}/delete-permanent`, {
+        method: "DELETE",
+      });
+      alert("✅ 기록이 영구 삭제되었습니다.");
+
+      // 영구 삭제 후 my-records로 이동
+      navigate("/my-records");
+    } catch (err) {
+      console.error("❌ 영구 삭제 실패:", err);
+      alert("영구 삭제 실패");
+    }
+  } else {
+    // 취소 시 아무 작업 없이 팝업창을 닫고 그대로 `RecoverPage`에 남게 됩니다.
+    console.log("삭제가 취소되었습니다.");
+  }
+};
 
   if (!recoveryData) return <div>로딩 중...</div>;
 
@@ -57,7 +77,8 @@ const RecoverPage = () => {
       <p><strong>평균 페이스:</strong> {recoveryData.pace}</p>
       <div className={styles.buttons}>
         <button onClick={handleRestore}>✅ 복구하기</button>
-        <button onClick={handleCancel}>❌ 취소</button>
+        <button onClick={() => handlePermanentDelete(recoveryData.id)}>🗑️ 삭제</button>
+        <button onClick={handleCancel}>취소</button>
       </div>
     </div>
   );


### PR DESCRIPTION
✨ 작업 내용
복구 탭에서 삭제 버튼 클릭 시 확인 팝업이 뜨고, 확인을 누르면 영구 삭제가 수행되도록 수정
RecoverPage에서 삭제 시 에러 발생 문제 해결 (navigate() 없이도 정상 처리되도록 로직 수정)
복구 상세 화면에서 버튼 순서 정리: ✅ 복구하기 → 🗑️ 삭제 → 취소 순으로 변경
복구된 기록에 대한 UI 구성 완료 (버튼 기능 정리 포함)

❌ 해결한 문제
삭제 버튼 클릭 후 팝업 확인 시 Recover.jsx로 이동하지 않고 콘솔에 오류 발생하던 문제
navigate 없이 삭제 함수만 실행되며 TypeError: Cannot read properties of null 발생
복구 상세 페이지의 삭제 버튼이 팝업은 뜨지만 실제 삭제 확인이 구현되지 않았던 문제

🔧 변경 사항
RecoverDetail.jsx 또는 detailMyRecord.jsx에서 삭제 로직을 handlePermanentDelete 안에 정리하고, 삭제 요청 후 UI 갱신 처리
팝업창 내 버튼 3종의 시맨틱 및 UX 정렬
✅ 복구하기 → 복구 API 호출 후 페이지 이동
🗑️ 삭제 → 팝업 → 확인 시 DELETE 요청
취소 → 팝업 닫기
버튼 순서 UX 기준에 맞게 재배치