### PR TITLE
인기코스 추가

### DIFF
--- a/src/pages/CourseStatsSection.jsx
+++ b/src/pages/CourseStatsSection.jsx
@@ -1,0 +1,80 @@
+// src/pages/CourseStats.jsx
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+import styles from "./courseStats.module.css";
+
+const CourseStats = () => {
+  const { courseId } = useParams();
+  const { accessToken } = useAuth();
+  const [stats, setStats] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const res = await fetch(
+          `http://localhost:8080/stats/recommended-course/${courseId}`,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        );
+
+        if (!res.ok) throw new Error("통계 로딩 실패");
+
+        const data = await res.json();
+        setStats(data);
+      } catch (err) {
+        console.error("❌ 코스 통계 불러오기 실패:", err);
+        setError("통계를 불러오지 못했습니다.");
+      }
+    };
+
+    fetchStats();
+  }, [courseId, accessToken]);
+
+  if (error) return <p>{error}</p>;
+  if (!stats) return <p>📡 통계를 불러오는 중...</p>;
+
+  const myRank = stats.topRunners.findIndex(
+    (r) => r.runnerName === stats.myName
+  ) + 1;
+
+  return (
+    <div className={styles.container}>
+      <h2>{stats.courseTitle}</h2>
+      <p>👤 생성자: {stats.creatorName}</p>
+      <p>📏 거리: {stats.courseDistanceKm}km</p>
+
+      <div className={styles.statsBox}>
+        <p>🔥 전체 완주 수: {stats.totalCompletionCount}회</p>
+        <p>👥 참여자 수: {stats.uniqueRunnerCount}명</p>
+        <p>⏱️ 평균 완주 시간: {(stats.averageCompletionTimeSeconds / 60).toFixed(1)}분</p>
+        <p>🏃 평균 페이스: {stats.averagePace}분/km</p>
+      </div>
+
+      <div className={styles.myStats}>
+        <h3>내 기록</h3>
+        <p>✅ 내 완주 수: {stats.myCompletionCount}회</p>
+        <p>🥇 내 최고 기록: {stats.myBestTimeSeconds ? (stats.myBestTimeSeconds / 60).toFixed(1) + "분" : "-"}</p>
+        <p>⏱️ 내 평균 페이스: {stats.myAveragePace || "-"}분/km</p>
+        <p>📊 내 순위: {myRank > 0 ? `${myRank}위` : "순위권 밖"}</p>
+      </div>
+
+      <div className={styles.ranking}>
+        <h3>🏆 TOP 5 러너</h3>
+        <ul>
+          {stats.topRunners.map((runner, idx) => (
+            <li key={idx}>
+              {idx + 1}위 - {runner.runnerName} | {runner.bestCompletionTimeSeconds / 60}분 | {runner.bestPace}분/km
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default CourseStats;

--- a/src/pages/CourseStatsSection.module.css
+++ b/src/pages/CourseStatsSection.module.css
@@ -1,0 +1,17 @@
+.container {
+  background: #f9f9f9;
+  padding: 16px;
+  border-radius: 12px;
+  margin-top: 20px;
+}
+
+.statsBox,
+.myStats,
+.ranking {
+  margin-top: 12px;
+  line-height: 1.6;
+}
+
+.ranking ul {
+  padding-left: 1.2rem;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -14,6 +14,7 @@ const Home = () => {
   const navigate = useNavigate();
   const authFetch = useAuthFetch();
   const { accessToken } = useAuth();
+  const [popularCourses, setPopularCourses] = useState([]);
 
   useEffect(() => {
     if (!accessToken) return;
@@ -30,10 +31,6 @@ const Home = () => {
 
     const fetchRecommendations = async () => {
       try {
-        /*const pos = await new Promise((resolve, reject) => {
-          navigator.geolocation.getCurrentPosition(resolve, reject);
-        });
-        const { latitude, longitude } = pos.coords;*/
 
         const res = await authFetch(
           `http://localhost:8080/course?sortType=LIKE`
@@ -47,14 +44,25 @@ const Home = () => {
       }
     };
 
+    const fetchPopularCourses = async () => {
+      try {
+        const res = await fetch("http://localhost:8080/stats/popular-courses");
+        const data = await res.json();
+        setPopularCourses(data);
+      } catch (err) {
+        console.error("인기 코스 불러오기 실패:", err);
+      }
+    };
+
     fetchUser();
     fetchRecommendations();
+    fetchPopularCourses();
   }, [accessToken]);
 
   useEffect(() => {
     if (localStorage.getItem("unsavedRun")) {
       setShowRecoveryPrompt(true);
-    }
+    } 
   }, []);
 
   const handleRecover = () => {
@@ -68,6 +76,10 @@ const Home = () => {
 
   const handleClickCourse = (id) => {
     navigate(`/course/${id}`);
+  };
+
+  const handleClickStats = (id) => {
+    navigate(`/course-stats/${id}`);
   };
 
   if (!user) return <div>사용자 정보를 불러오는 중...</div>;
@@ -129,6 +141,26 @@ const Home = () => {
           >
             ➕ 더보기
           </button>
+        </div>
+      </div>
+      <div className={styles.popularBox}>
+        <h2>🔥 인기 추천 코스</h2>
+        <div className={styles.popularGrid}>
+          {popularCourses.slice(0, 10).map((course) => (
+            <div
+              key={course.courseId}
+              className={styles.popularCard}
+              onClick={() => handleClickStats(course.courseId)}
+            >
+              <p className={styles.popularTitle}>{course.courseTitle}</p>
+              <p className={styles.popularInfo}>
+                📏 {course.distanceKm}km | 👥 {course.uniqueRunnerCount}명
+              </p>
+              <p className={styles.popularStats}>
+                🔥 {course.totalCompletionCount}회 | ⏱ {course.averagePace}분/km
+              </p>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/src/pages/MyFavorites.jsx
+++ b/src/pages/MyFavorites.jsx
@@ -60,7 +60,7 @@ const MyFavorites = () => {
               className={styles.favoriteItem}
               onClick={() => handleClick(course.courseId)}
             >
-              <p className={styles.courseTitle}>{course.title}</p>
+              <p className={styles.endLocationName}>{course.title}</p>
               <p>{course.totalDistance} km</p>
               {/* ❤️ {course.likes} */}
               {/* <p>{course.description || "설명이 없습니다."}</p> */}


### PR DESCRIPTION
✨ 작업 내용
📈 CourseStats.jsx 페이지 구현

GET /stats/recommended-course/{id} 호출 후 통계 데이터 렌더링

내 기록, 평균 통계, TOP 5 랭커 표시

🔥 PopularCourses.jsx 페이지 구현

GET /stats/popular-courses 호출 후 인기 코스 10개 렌더링

🏠 Home.jsx에 인기 코스 섹션 추가

추천 경로 아래에 "🔥 인기 추천 코스" 섹션 표시
가로 슬라이드 형태로 최대 10개 출력
⭐ MyFavorites.jsx에 백엔드 변경사항 반영
title 대신 endLocationName을 우선 표시
alt, 텍스트, 썸네일 설명에 목적지명 우선 적용

🧪 테스트 방법
/course-stats/:id 진입 시 해당 추천 코스의 통계 정상 출력되는지 확인
/popular-courses 페이지에서 인기 추천 코스 10개 목록 확인
Home 진입 시 추천 경로 하단에 인기 코스 섹션 정상 렌더링 확인
마이페이지 → 즐겨찾기 탭에서 목적지명(endLocationName)으로 제목이 보이는지 확인

🎯 관련 이슈
#추천코스-통계-조회
#인기코스-홈표시
#즐겨찾기-UI-엔드로케이션표시